### PR TITLE
Pin 3rd-party actions to SHA1

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Wait for tests to succeed
-        uses: fountainhead/action-wait-for-check@v1.0.0
+        uses: fountainhead/action-wait-for-check@4699210ccc66e2a13260803fadbb77085421b891 #v1.0.0
         id: wait-for-tests
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -13,7 +13,7 @@ jobs:
     name: Auto-update open PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: chinthakagodawita/autoupdate-action@v0.1.4
+      - uses: chinthakagodawita/autoupdate-action@699da47083dddb66e5f5d2d48825b2e375a1d6c3 #v0.1.4
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_MSG: "Branch was auto-updated with the latest."

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -37,7 +37,7 @@ jobs:
           github.event.review.state == 'approved' &&          
           github.event.check_suite.status == 'completed' &&
           github.event.check_suite.conclusion == 'success'
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf #v1
         with:
           github_token: ${{ env.TOKEN }}
           labels: ready to merge
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Flag work in progress
         if: github.event.pull_request.draft == true
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf #v1
         with:
           github_token: ${{ env.TOKEN }}
           labels: work in progress

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -20,32 +20,32 @@ jobs:
     if: contains(github.event.*.state, 'open')
     steps:
       - name: Move to backlog
-        uses: takanabe/github-actions-automate-projects@v0.0.1
+        uses: takanabe/github-actions-automate-projects@150a339e20050890efd49d37696fee9f21657459 #v0.0.1
         if: contains(github.event.*.labels.*.name, 'discovery')
         env:
           GITHUB_PROJECT_COLUMN_NAME: Backlog
       - name: Move to hold
-        uses: takanabe/github-actions-automate-projects@v0.0.1
+        uses: takanabe/github-actions-automate-projects@150a339e20050890efd49d37696fee9f21657459 #v0.0.1
         if: |
           contains(github.event.*.labels.*.name, 'blocked') ||
           contains(github.event.*.labels.*.name, 'on hold')
         env:
           GITHUB_PROJECT_COLUMN_NAME: On hold
       - name: Ready for code review
-        uses: takanabe/github-actions-automate-projects@v0.0.1
+        uses: takanabe/github-actions-automate-projects@150a339e20050890efd49d37696fee9f21657459 #v0.0.1
         if: |
           contains(github.event.*.labels.*.name, 'needs: code review')
         env:
           GITHUB_PROJECT_COLUMN_NAME: Code review
       - name: Move to testing
-        uses: takanabe/github-actions-automate-projects@v0.0.1
+        uses: takanabe/github-actions-automate-projects@150a339e20050890efd49d37696fee9f21657459 #v0.0.1
         if: |
           contains(github.event.*.labels.*.name, 'needs: browser testing') ||
           contains(github.event.*.labels.*.name, 'needs: branch testing')
         env:
           GITHUB_PROJECT_COLUMN_NAME: Testing
       - name: Ready to merge
-        uses: takanabe/github-actions-automate-projects@v0.0.1
+        uses: takanabe/github-actions-automate-projects@150a339e20050890efd49d37696fee9f21657459 #v0.0.1
         if: contains(github.event.*.labels.*.name, 'ready for merge')
         env:
           GITHUB_PROJECT_COLUMN_NAME: Ready for merge?

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,13 +155,13 @@ jobs:
         node: [10]
     steps:
       - name: BrowserStack environment setup
-        uses: "browserstack/github-actions/setup-env@master"
+        uses: "browserstack/github-actions/setup-env@00ce173eae311a7838f80682a5fad5144c4219ad #master"
         with:
           username: ${{ secrets.BROWSERSTACK_USER }}
           access-key: ${{ secrets.BROWSERSTACK_KEY }}
 
       - name: Start BrowserStackLocal
-        uses: browserstack/github-actions/setup-local@master
+        uses: browserstack/github-actions/setup-local@00ce173eae311a7838f80682a5fad5144c4219ad #master
         with:
           local-testing: start
           local-identifier: random
@@ -219,6 +219,6 @@ jobs:
 
       - name: Stop BrowserStackLocal
         if: always()
-        uses: browserstack/github-actions/setup-local@master
+        uses: browserstack/github-actions/setup-local@00ce173eae311a7838f80682a5fad5144c4219ad #master
         with:
           local-testing: stop


### PR DESCRIPTION
Hi!

Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.

This PR was submitted by a script.
